### PR TITLE
bugfix #104 remove versioned release for client.

### DIFF
--- a/build-release.bash
+++ b/build-release.bash
@@ -70,12 +70,6 @@ echo "***********************"
 
 pushd "$CLIENT">/dev/null
 
-# change client version numbers. these are only used by getdown.
-oldversion=$(grep "version = " "getdown.txt" | cut -d" " -f 3)
-newversion=$(date +%Y%m%d%H%M%S)
-sed -i -E "s/version.*=.*$oldversion/version = $newversion/" "getdown.txt"
-echo "$newversion" >"version.txt" # update version.txt to match getdown.txt
-
 declare -a clientfiles=(
     "bg.png"
     "getdown.jar"
@@ -84,14 +78,12 @@ declare -a clientfiles=(
     "growup.ico"
     "growup.png"
     "user.config"
-    "version.txt"
 )
 for file in "${clientfiles[@]}"; do
     cp -r "$file" "$CLIENTBUILDDIR"
 done
 # move this separately, it's huge. from build task.
 mv build/libs/client-launcher*.jar "$CLIENTBUILDDIR"/"$CLIENTJARNAME"
-rm "version.txt" # temporary build file
 popd>/dev/null
 
 # process getdown
@@ -102,7 +94,7 @@ mkdir "$(basename "$CLIENTUSERDIR")" "$(basename "$CLIENTHTTPDIR")"
 # generate package for user. If using git bash, follow instructions here:
 # https://ranxing.wordpress.com/2016/12/13/add-zip-into-git-bash-on-windows/
 # # TODO: add MSI, deb package installers here if wanted.
-zip -r "$CLIENTZIPNAME" . -9 --exclude "/$(basename "$CLIENTUSERDIR")/*" --exclude "/$(basename "$CLIENTHTTPDIR")/*" --exclude "digest.txt" --exclude "digest2.txt" --exclude "version.txt">/dev/null
+zip -r "$CLIENTZIPNAME" . -9 --exclude "/$(basename "$CLIENTUSERDIR")/*" --exclude "/$(basename "$CLIENTHTTPDIR")/*" --exclude "digest.txt" --exclude "digest2.txt">/dev/null
 
 # generate files for http
 for f in *; do
@@ -116,11 +108,6 @@ for f in *; do
         fi
     fi
 done
-
-# restore old version number to file after we've copied it
-pushd "$CLIENT">/dev/null
-sed -i -E "s/version.*=.*$newversion/version = $oldversion/" "getdown.txt"
-popd>/dev/null
 
 popd>/dev/null
 echo "done making client."

--- a/client-core/src/com/benberi/cadesim/Constants.java
+++ b/client-core/src/com/benberi/cadesim/Constants.java
@@ -18,7 +18,6 @@ public class Constants {
      * Version of client
      */
     public static  String VERSION = "1.9.93";
-    public static volatile boolean SERVER_VERSION_IDENTICAL = true;
     public static final int PROTOCOL_VERSION = 1993; // MUST match server
 
 	public static final int MAX_NAME_SIZE = 19;   // name of player

--- a/client-core/src/com/benberi/cadesim/game/scene/impl/connect/ConnectScene.java
+++ b/client-core/src/com/benberi/cadesim/game/scene/impl/connect/ConnectScene.java
@@ -222,40 +222,12 @@ public class ConnectScene implements GameScene, InputProcessor {
         buttonConn = new ImageButton(loginButtonStyle); //Set the button up
         buttonConn.addListener(new ClickListener() {//runs update if there is one before logging in 
             public void clicked(InputEvent event, float x, float y){
-            	//only run if there is an update listed on server
-            	if(!Constants.SERVER_VERSION_IDENTICAL) {
-	                try {
-	                	System.out.println("Performing update; deleting necessary files...");
-	                	//delete required files in order to update client
-	                	File digest1 = new File("digest.txt");
-	                	File digest2 = new File("digest2.txt");
-	                	File version = new File("version.txt");
-                		digest1.delete();
-                		System.out.println("Deleted file: digest.txt");
-                		digest2.delete();
-                		System.out.println("Deleted file: digest2.txt");
-                		version.delete();
-                		System.out.println("Deleted file: version.txt");
-						ProcessBuilder pb = new ProcessBuilder("java", "-jar", "getdown.jar");
-						@SuppressWarnings("unused")
-						Process p = pb.start(); //assign to process for something in future
-						System.out.println("Performing update; closing client and running getdown...");
-						System.exit(0);
-					}catch(Exception e){
-						System.out.println(e);
-						System.out.println("Unable to start getdown.jar; run manually.");
-						System.out.println("Be sure to delete digest files before running.");
-						}
-	                
-	                }
-	            else {
-	                try {
-	                    performLogin();
-	                    buttonConn.toggle();
-	                } catch (UnknownHostException e) {
-	                    return;
-	                }
-	            }
+                try {
+                    performLogin();
+                    buttonConn.toggle();
+                } catch (UnknownHostException e) {
+                    return;
+                }
             }});
         buttonConn.setPosition(165, 290);
       //login button

--- a/client-launcher/getdown.txt
+++ b/client-launcher/getdown.txt
@@ -1,9 +1,6 @@
 # The URL from which the client is downloaded (must start with http:// and end with trailing /). URL is case sensitive.
 appbase = https://plaza-in-a-heatwave.github.io/Cadesim/growup/client/http/
 
-# The version number is auto generated in build-release and is only used by getdown.
-version = 20201030
-
 # UI Configuration
 ui.name = CadeSim Updater
 ui.icon = growup.png
@@ -23,4 +20,5 @@ class = com.benberi.cadesim.desktop.DesktopLauncher
 
 strict_comments = true
 resource = user.config
-resource = version.txt
+
+apparg = --no-update


### PR DESCRIPTION
This removes the versioning aspect (and possibly fixes some of the install problems). The cadesim jar now auto-launches getdown straight away unless one of the following are in place:
* autoupdate parameter in user.config is defined as something that is not "yes"
* an argument, --no-update is passed.

E.g. to prevent getdown being called in an endless loop, it passes the --no-update argument.


**NOTE** when this is deployed, it needs a ```version.txt``` file to be placed containing a value equal to or higher than ```20201031153846```