### PR TITLE
Feature/#105 match logfiles to rooms

### DIFF
--- a/server/src/com/benberi/cadesim/server/ServerContext.java
+++ b/server/src/com/benberi/cadesim/server/ServerContext.java
@@ -7,16 +7,15 @@ import com.benberi.cadesim.server.model.cade.map.BlockadeMap;
 import com.benberi.cadesim.server.model.cade.BlockadeTimeMachine;
 import com.benberi.cadesim.server.codec.packet.ServerPacketManager;
 import com.benberi.cadesim.server.config.Constants;
+import com.benberi.cadesim.server.config.ServerConfiguration;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
-import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.concurrent.ThreadLocalRandom;
+import java.time.format.DateTimeFormatterBuilder;
 
 /**
  * The server context containing references to every massive part of the
@@ -49,7 +48,14 @@ public class ServerContext {
      */
     private BlockadeMap map;
 
+    /*
+     * Logging options
+     */
     private static File logFile = null;
+    private static File unifiedLogFile = null;
+    public final static boolean LOG_MODE_INSTANCE = true;  // cheap enum for logMode lol
+    public final static boolean LOG_MODE_UNIFIED  = false;
+    private static boolean logMode = LOG_MODE_UNIFIED;
 
     private ServerPacketManager packets;
 
@@ -78,38 +84,91 @@ public class ServerContext {
         this.packets = new ServerPacketManager(this);
         this.updater = new Updater(this);
         this.regressionTests = new RegressionTests(this, false); // verbose switch
+
+        // instruct the logger to switch across to using per-instance logs
+        // now that we have access to context info and can create meaningful logfile names
+        ServerContext.setLogMode(ServerContext.LOG_MODE_INSTANCE);
     }
 
-    public static void createLogFile() {
-        new File(Constants.logDirectory).mkdirs();
-
-        // log filenames are timestamped to reduce chance of conflict. Additionally a random int is used.
-        // conflicting logs interleave, but otherwise work as normal.
-        String datePrefix = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss-SSSSSSX_").withZone(ZoneOffset.UTC)
-                .format(Instant.now()) + ThreadLocalRandom.current().nextInt(0, 2147483647) + "_";
-        logFile = new File(Constants.logDirectory + "/" + datePrefix + Constants.logName);
-        try {
-            logFile.createNewFile();
-            log("Using logfile: " + logFile.getPath());
-        } catch (IOException e) {
-            System.out.println("failed to create log file: " + logFile.getName() + " , check log directory permissions");
-            System.exit(Constants.EXIT_ERROR_CANT_CREATE_LOGS);
-        }
+    public static boolean getLogMode() {
+        return logMode;
+    }
+    public static void setLogMode(boolean logMode) {
+        ServerContext.logMode = logMode;
     }
 
+    /**
+     * Log a message. Depending on logMode, will log to either a unified or an instance logfile.
+     * @param message the message to log.
+     */
     public static void log(String message) {
-        if (logFile == null) {
-            createLogFile();
+        // format message
+        String timestamp = ZonedDateTime.now(ZoneOffset.UTC).format(
+            new DateTimeFormatterBuilder().appendInstant(3).toFormatter()
+        );
+        message = "[" + timestamp + "]: " + message + "\n";
+
+        // put to file
+        if (getLogMode() == ServerContext.LOG_MODE_UNIFIED) {
+            logUnified(message);
+        }
+        else
+        {
+            logInstance(message);
+        }
+
+        // also print to stdout so we can see what's going on...
+        System.out.print(message);
+    }
+
+    /**
+     * Print to a "unified log" file that is shared with all cadesim instances.
+     * This is only to be used before the main logfile is created. Useful for catching error messages.
+     * This approach taken so that main logfiles can be per-instance and also be named according to port etc.
+     *
+     * Use setLogMode() to change to instance logs.
+     *
+     * @param message the message to log.
+     */
+    private static void logUnified(String message) {
+        if (unifiedLogFile == null) {
+            new File(Constants.logDirectory).mkdirs();
+            unifiedLogFile = new File(Constants.logDirectory + "/" + "unified_" + Constants.logName);
+            try {
+                unifiedLogFile.createNewFile();
+            } catch (IOException e) {
+                System.out.println("failed to create unifiedLogFile: " + unifiedLogFile.getName() + " , check log directory permissions");
+                System.exit(Constants.EXIT_ERROR_CANT_CREATE_LOGS);
+            }
         }
         try {
-        	String timestamp = ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
-            message = "[" + timestamp + "]: " + message + "\n";
+            Files.write(ServerContext.unifiedLogFile.toPath(), message.getBytes(), StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 
-            // put to log file
+    /**
+     * Print to an "instance log" which is unique for each instance of cadesim.
+     * This is to be used after server bootstraps.
+     * Use setLogMode() to change to unified, but you probably won't want to do this.
+     * @param message
+     */
+    private static void logInstance(String message) {
+        if (logFile == null) {
+            new File(Constants.logDirectory).mkdirs();
+
+            // TODO names are based on ports. Could we hash each port to a unique room name?
+            logFile = new File(Constants.logDirectory + "/" + "port_" + ServerConfiguration.getPort() + "_" + Constants.logName);
+            try {
+                logFile.createNewFile();
+            } catch (IOException e) {
+                System.out.println("failed to create log file: " + logFile.getName() + " , check log directory permissions");
+                System.exit(Constants.EXIT_ERROR_CANT_CREATE_LOGS);
+            }
+        }
+        try {
             Files.write(ServerContext.logFile.toPath(), message.getBytes(), StandardOpenOption.APPEND);
-
-            // also print to stdout so we can see what's going on...
-            System.out.print(message);
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/server/src/com/benberi/cadesim/server/service/GameServerBootstrap.java
+++ b/server/src/com/benberi/cadesim/server/service/GameServerBootstrap.java
@@ -49,6 +49,7 @@ public class GameServerBootstrap {
      * @throws InterruptedException
      */
     private void startServer() throws InterruptedException {
+        ServerContext.log("Welcome to " + Constants.name + " (version " + Constants.VERSION + ")" + ".");
         ServerContext.log("Using config: " + ServerConfiguration.getConfig());
         ServerContext.log("Starting up the host server....");
         CadeServer server = new CadeServer(context, this); // to notify back its done
@@ -87,6 +88,11 @@ public class GameServerBootstrap {
     public static void main(String[] args) throws NumberFormatException, InterruptedException{
         start = System.currentTimeMillis();
 
+        // add a shutdown hook and print a log message when this happens.
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+          public void run() { ServerContext.log("Cadesim shut down successfully. Doei!"); }
+        });
+
         // quick parse to check for the do-nothing argument. If it's there, exit immediately.
         // this is necessary to avoid spam during the autoupdate process.
         // (we use --do-nothing as getdown.jar wants to start an application.)
@@ -109,14 +115,11 @@ public class GameServerBootstrap {
             }
         }
 
-        ServerContext.log("Welcome to " + Constants.name + " (version " + Constants.VERSION + ")" + ".");
-
         // set up maps
         if (!ServerConfiguration.loadAvailableMaps()) {
             ServerContext.log("ERROR: Failed to find maps folder. create a folder called \"maps\" in the same directory.");
             System.exit(Constants.EXIT_ERROR_CANT_FIND_MAPS);
         }
-        ServerContext.log("Loaded " + ServerConfiguration.getAvailableMaps().size() + " maps.");
         ServerConfiguration.pregenerateNextMapName();
 
         // set up CLI options
@@ -372,7 +375,6 @@ public class GameServerBootstrap {
                 	ServerConfiguration.setMapName(
                         ServerConfiguration.getRandomMapName()
                 	);
-                    ServerContext.log("No map specified, automatically chose random map: " + ServerConfiguration.getMapName());
                 } catch(NullPointerException e) {
                     ServerContext.log("ERROR: Failed to find maps folder. create a folder called \"maps\" in the same directory.");
                     System.exit(Constants.EXIT_ERROR_CANT_FIND_MAPS);
@@ -380,7 +382,6 @@ public class GameServerBootstrap {
             }
             else {
             	ServerConfiguration.setMapName(cmd.getOptionValue("m"));
-                ServerContext.log("Using user specified map:" + ServerConfiguration.getMapName());
             }
 
             // test mode overrides

--- a/server/src/com/benberi/cadesim/server/service/Updater.java
+++ b/server/src/com/benberi/cadesim/server/service/Updater.java
@@ -101,9 +101,9 @@ public class Updater {
     private static void cleanupAndRestart() {
         File f = new File(Constants.AUTO_UPDATING_LOCK_DIRECTORY_NAME);
         if (f.delete()) {
-            ServerContext.log("[updater] deleted lockfile " + f.getPath());
+            ServerContext.log("[updater] Deleted lockfile " + f.getPath());
         } else {
-            ServerContext.log("[updater] couldn't delete lockfile " + f.getPath());
+            ServerContext.log("[updater] Couldn't delete lockfile " + f.getPath());
         }
         restartServer();
     }
@@ -121,13 +121,13 @@ public class Updater {
         try {
             File jarFile = new File(codeSource.getLocation().toURI().getPath());
             jarFileName = jarFile.getCanonicalPath();
-            ServerContext.log("[updater] using jar file name: " + jarFileName);
+            ServerContext.log("[updater] Using jar file name: " + jarFileName);
         } catch (URISyntaxException e) {
             e.printStackTrace();
         } catch (IOException e) {
             e.printStackTrace();
         } catch (NullPointerException e) {
-            ServerContext.log("[updater] jar path was null. /hint/ Try exporting as a jar, select \"Extract required libraries into generated JAR\"");
+            ServerContext.log("[updater] Jar path was null. /hint/ Try exporting as a jar, select \"Extract required libraries into generated JAR\"");
             e.printStackTrace();
         }
 
@@ -148,24 +148,24 @@ public class Updater {
 
             // restart the server by creating a new process & exiting.
             ProcessBuilder pb = new ProcessBuilder(arglist);
-            ServerContext.log("[updater] calling new process with:" + String.join(" ", arglist));
+            ServerContext.log("[updater] Calling new process with:" + String.join(" ", arglist));
             try {
                 pb.start();
             } catch (IOException e) {
-                ServerContext.log("[updater] failed to spawn new server process when restarting. (" + e + ")");
+                ServerContext.log("[updater] Failed to spawn new server process when restarting. (" + e + ")");
                 System.exit(Constants.EXIT_ERROR_CANT_UPDATE);
             }
             ServerContext.log("[updater] Successfully spawned new process. Quitting this one.");
             System.exit(Constants.EXIT_SUCCESS_SCHEDULED_UPDATE);
         } else {
-            ServerContext.log("[updater] failed to spawn new server process: server not running from jar.");
+            ServerContext.log("[updater] Failed to spawn new server process: server not running from jar.");
             System.exit(Constants.EXIT_ERROR_CANT_UPDATE);
         }
     }
 
     /**
      * Updater: perform automatic update.
-     * May exit and/or restart the process.
+     * Will either exit or restart the process depending on the outcome.
      *
      * @throws InterruptedException
      * @throws IOException
@@ -173,13 +173,16 @@ public class Updater {
      * Usage: use to check for updates at a given time.
      */
     public static void update() throws InterruptedException, IOException {
-        // check for updates and restart the server if we need to
+        ServerContext.log("[updater] Checking for server updates.");
+
         java.io.File f = new java.io.File(Constants.AUTO_UPDATING_LOCK_DIRECTORY_NAME);
-        int sleep_ms = 2000;
+        int sleep_ms = 1000;
         int sleepTotal = 0;
         boolean fileLockSuccess = true;
         while (!f.mkdir()) {
-            ServerContext.log("[updater]  Waiting to update... (" + sleepTotal + ")");
+            if (((sleepTotal / sleep_ms) % 5) == 4) { // log every 5x sleep_ms, offset 4 iterations
+                ServerContext.log("[updater] Waiting to update... (" + (sleepTotal / 1000) + "s)");
+            }
             Thread.sleep(sleep_ms);
             sleepTotal += sleep_ms;
 
@@ -221,15 +224,15 @@ public class Updater {
                 ProcessBuilder pb = new ProcessBuilder("java", "-jar", "getdown.jar");
                 Process p = pb.start();
 
-                ServerContext.log("[updater] waiting for getdown to finish before restarting server...");
+                ServerContext.log("[updater] Waiting for getdown to finish before restarting server...");
                 if (p.waitFor(Constants.AUTO_UPDATE_MAX_WAIT_GETDOWN_MS, TimeUnit.MILLISECONDS)) { // blocks, times out
-                    ServerContext.log("[updater] getdown finished successfully. Restarting server...");
+                    ServerContext.log("[updater] Getdown finished successfully. Restarting server...");
                 } else {
-                    ServerContext.log("[updater] getdown didn't close in time. Maybe it crashed? Restarting server...");
+                    ServerContext.log("[updater] Getdown didn't close in time. Maybe it crashed? Restarting server...");
                 }
                 restartServer();
             } catch (Exception e) {
-                ServerContext.log("[updater] exception when calling getdown: " + e);
+                ServerContext.log("[updater] Exception when calling getdown: " + e);
                 cleanupAndRestart();
             }
         } else { // didnt lock - no cleanup needed, just restart server :)

--- a/server/src/com/benberi/cadesim/server/service/Updater.java
+++ b/server/src/com/benberi/cadesim/server/service/Updater.java
@@ -47,7 +47,6 @@ public class Updater {
         // add a few sec delay before doing anything to give any
         // previous instances a chance to exit
         try {
-            ServerContext.log("[updater] Sleeping for a few seconds to give previous server processes a chance to exit.");
             Thread.sleep(2000);
         } catch (InterruptedException e) {
             // pass
@@ -64,7 +63,7 @@ public class Updater {
                 lastUpdateWasOurs = true;
             }
         } catch (IOException e) {
-            ServerContext.log("[updater] Couldn't open idfile so assume wasn't ours (or isn't there)");
+            // Couldn't open idfile so assume wasn't ours (or isn't there)
         }
 
         // if last update was ours, clean up
@@ -76,21 +75,19 @@ public class Updater {
             boolean deleteSucceeded = true;
             for (String s : toDelete) {
                 File f = new File(s);
-                if (f.delete()) {
-                    ServerContext.log("[updater] deleted " + f.getPath() + " on startup.");
-                } else {
-                    ServerContext.log("[updater] couldn't delete " + f.getPath() + " on startup");
+                if (!f.delete()) {
+                    ServerContext.log("[updater] Error: couldn't delete " + f.getPath() + " on startup");
                     deleteSucceeded = false;
                 }
             }
 
             if (!deleteSucceeded) {
-                ServerContext.log("[updater] Error: delete of at least one update file failed.");
+                ServerContext.log("[updater] Error: delete of at least one update file failed. This may impact other local Cadesim servers.");
             }
         }
         else
         {
-            ServerContext.log("[updater] the lockfile isn't ours (or there is no lockfile), so doing nothing.");
+            // the lockfile isn't ours (or there is no lockfile), so doing nothing.
         }
     }
 

--- a/server/start_servers.py
+++ b/server/start_servers.py
@@ -10,13 +10,13 @@ import subprocess, platform, time
 DETACHED_PROCESS = 0x00000008
 
 for server_args in [
-    "java -jar cadesim-server.jar -p 4970 --schedule-updates 04:00",
-    "java -jar cadesim-server.jar -p 4971 --schedule-updates 04:00",
-    "java -jar cadesim-server.jar -p 4972 --schedule-updates 04:00",
-    "java -jar cadesim-server.jar -p 4973 --schedule-updates 04:00",
-    "java -jar cadesim-server.jar -p 4974 --schedule-updates 04:00",
+    "java -jar cadesim-server.jar -p 4970 --schedule-updates 04:00 --update-at-startup",
+    "java -jar cadesim-server.jar -p 4971 --schedule-updates 04:00 --update-at-startup",
+    "java -jar cadesim-server.jar -p 4972 --schedule-updates 04:00 --update-at-startup",
+    "java -jar cadesim-server.jar -p 4973 --schedule-updates 04:00 --update-at-startup",
+    "java -jar cadesim-server.jar -p 4974 --schedule-updates 04:00 --update-at-startup",
 ]:
-    time.sleep(0.1) # add time granularity to prevent two servers sharing same logfile
+    time.sleep(0.1) # stagger any races for file locks, flatten system peak load
     if(any(platform.win32_ver())):
         print("started Cadesim instance (pid: " + str(subprocess.Popen(server_args.split(" "), close_fds=True, creationflags=DETACHED_PROCESS).pid) + ")")
     else:


### PR DESCRIPTION
Allow lognames to be named according to config items:
* all log() messages made before parsing completes use a unified logfile.
* unified logfile is writable by all cadesim instances.
* all log() calls after parsing are redirected to per-instance logfiles.
* instance logfiles are nameable according to config or derived values.

Minor other things:
* change logger case to be more consistent
* move updater code, welcome text so that they appear in the instance log
* move shutdown hook so that it only uses the instance log
* reduce spam from updater